### PR TITLE
Use root user credentials for mongodb exporter

### DIFF
--- a/roles/mongodb_exporter/tasks/deploy_mongodb_exporter.yaml
+++ b/roles/mongodb_exporter/tasks/deploy_mongodb_exporter.yaml
@@ -18,7 +18,7 @@
 - name: Set default mongodb-exporter flags
   set_fact:
     mongodb_exporter_default_flags:
-      - "--mongodb.uri=mongodb://{{ mongodb_graylog_username }}:{{ mongodb_graylog_password }}@127.0.0.1:27017/"
+      - "--mongodb.uri=mongodb://{{ mongodb_root_username }}:{{ mongodb_root_password }}@127.0.0.1:27017/"
 
 - name: Compile custom and default MongoDB exporter flags
   set_fact:


### PR DESCRIPTION
After authentication was enabled for MongoDB container, the exporter cannot connect to the database. Need to use root user credentials instead of graylog user credentials.