### PR TITLE
fix: Fix Warnings when starting fluentd in cloud and on VM

### DIFF
--- a/roles/fluentd/files/conf.d/inputs/input-audit.conf
+++ b/roles/fluentd/files/conf.d/inputs/input-audit.conf
@@ -8,5 +8,4 @@
   time_key time
   read_from_head true
   encoding UTF-8
-  from_encoding UTF-8
 </source>

--- a/roles/fluentd/files/conf.d/inputs/input-docker.conf
+++ b/roles/fluentd/files/conf.d/inputs/input-docker.conf
@@ -7,7 +7,6 @@
   format json
   read_from_head true
   encoding UTF-8
-  from_encoding UTF-8
 </source>
 
 <filter docker.var.lib.docker.containers.*.*.log>

--- a/roles/fluentd/files/conf.d/inputs/input-messages.conf
+++ b/roles/fluentd/files/conf.d/inputs/input-messages.conf
@@ -8,7 +8,6 @@
   format syslog
   read_from_head true
   encoding UTF-8
-  from_encoding UTF-8
 </source>
 
 <source>
@@ -21,5 +20,4 @@
   format syslog
   read_from_head true
   encoding UTF-8
-  from_encoding UTF-8
 </source>

--- a/roles/fluentd/files/conf.d/outputs/output-null.conf
+++ b/roles/fluentd/files/conf.d/outputs/output-null.conf
@@ -1,3 +1,5 @@
-<match fluent.**>
-  @type null
-</match>
+<label @FLUENT_LOG>
+  <match fluent.**>
+    @type null
+  </match>
+</label>


### PR DESCRIPTION
added 'label' for fluentd system logs, removed the extra 'from_encoding' parameter with the same encoding